### PR TITLE
issue-002: 3-1.変数と可変性

### DIFF
--- a/variables/Cargo.toml
+++ b/variables/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "variables"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/variables/src/main.rs
+++ b/variables/src/main.rs
@@ -1,0 +1,26 @@
+fn main() {
+    // 変数 - mutあり: 可変、mutなし: 不変
+    let mut x = 5;
+    println!("The value of x is: {}", x);
+    x = 6;
+    println!("The value of x is: {}", x);
+
+    // 定数
+    // 1. 型を必ず注釈する
+    // 2. 命名規則: UPPER_SNAKE_CASE
+    const MAX_NUMBER: u32 = 99_999;
+    println!("The const value of MAX_NUMBER is: {}", MAX_NUMBER);
+
+
+    // シャドーイング
+    let y = 5;
+
+    let y = y + 1; // let で再定義（let無しの場合はコンパイルエラー）
+
+    {
+        let y = y * 2;
+        println!("The value of y in the inner scope is: {}", y); // 12になる
+    }
+
+    println!("The value of y is: {}", y); // 6になる（直前とはスコープがことなるため）
+}


### PR DESCRIPTION
## issue
#3 

## 対応内容
- 変数と可変性について
  - 変数と定数
    - let hoge; （mut）無しは定数ではない（let hoge 〜 で再定義できちゃう）
    - 定数は const で定義
      - 型を注釈する必要あり 
      - 定数はアッパーキャメルケース
        ```
        // 例
        const HOGE_FUGA: u32 = 1234;
        ```
    - なお再定義（シャドーイング）はできない
  - シャドーイング
    - 端的にいうと変数の再定義ができる（元の定義は隠蔽）  

## 補足
- none