### PR TITLE
issue-005: 3.3.関数

### DIFF
--- a/functions/Cargo.toml
+++ b/functions/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "functions"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/functions/src/main.rs
+++ b/functions/src/main.rs
@@ -1,0 +1,25 @@
+fn main() {
+    another_function(5);
+
+    print_labeled_measurement(3, 'h');
+
+    println!("The value of fn five ret value is: {}", five());
+
+    println!("The value of fn add_one ret value is: {}", add_one(123));
+}
+
+fn another_function(x: i32) {
+    println!("This is anothre_function. The value is: {}", x);
+}
+
+fn print_labeled_measurement(value: i32, label: char) {
+    println!("This is print_labeled_measurement. The value is: {}{}", value, label);
+}
+
+fn five() -> i32 {
+    5 * 10 // 戻り値にはセミコロンはつけない
+}
+
+fn add_one(x: i32) -> i32 {
+    x + 1 // 引数を取る場合も同様
+}


### PR DESCRIPTION
## issue
- #5 

## 概要
- 関数について
  - 式と文
  - 戻り値（return文に該当）にはセミコロン`;` つけない 