### PR TITLE
issue-013: enum

### DIFF
--- a/enums/enums/Cargo.toml
+++ b/enums/enums/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "enums"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/enums/enums/src/main.rs
+++ b/enums/enums/src/main.rs
@@ -1,0 +1,58 @@
+#[derive(Debug)]
+enum SomeStatus {
+    Prepare = 0,
+    Open = 1,
+    Close = 9,
+}
+
+impl SomeStatus {
+    fn get_code(&self) -> i32 {
+        match self {
+            SomeStatus::Prepare => SomeStatus::Prepare as i32,
+            SomeStatus::Open => SomeStatus::Open as i32,
+            SomeStatus::Close => SomeStatus::Close as i32,
+        }
+    }
+
+    fn get_name(&self) -> String {
+        match self {
+            SomeStatus::Prepare => String::from("prep."),
+            SomeStatus::Open => String::from("open."),
+            SomeStatus::Close => String::from("close."),
+        }
+    }
+}
+
+fn main() {
+    println!("1. {:#?} {}", SomeStatus::Prepare, SomeStatus::Prepare as i32);
+    println!("2. {:#?} {}", SomeStatus::Open, SomeStatus::Open as i32);
+    println!("3. {:#?} {}", SomeStatus::Close, SomeStatus::Close as i32);
+
+    let status = SomeStatus::Open;
+    println!("status code {}, name {}.", status.get_code(), status.get_name());
+
+    // match式
+    match status {
+        SomeStatus::Prepare => println!("準備中"),
+        SomeStatus::Open => println!("公開"),
+        SomeStatus::Close => println!("非公開"),
+    }
+
+    // Option<T> - unwrap() で T を取り出せる
+    let ans = add_one(Some(7));
+    println!("add 1 is {:#?}.", ans.unwrap());
+
+    // if let - enumの比較
+    if let SomeStatus::Close = status {
+        println!("it is close, anyway.");
+    } else {
+        println!("it is not close yet.");
+    }
+}
+
+fn add_one(x: Option<i32>) -> Option<i32> {
+    match x {
+        None => None,
+        Some(i) => Some(i + 1),
+    }
+}


### PR DESCRIPTION
## issue
- #13 

## 概要
- enum
  - code定義、code取得（キャスト）
  - 拡張（implでcode、nameを取得する（冗長感））
  - match式 / if let
    - enum判定
  - `Option<T>`
    - `Some(?)` と `None`
    - `Some(?)` から `T`値を抽出したい場合は `.unwrap()` 
      ```
      let hoge = Some(777);
      hoge.unwrap();  // これで 777 as i32
      ```
## 補足
- none